### PR TITLE
refactor(prompts): phase-scoped CMS technical context per agent

### DIFF
--- a/src/prompts/action.js
+++ b/src/prompts/action.js
@@ -7,91 +7,60 @@ import { getDeliverableFormat, getTechnicalContext } from './shared.js';
  * @param {string} cms - CMS type (ams, cs, eds)
  * @returns {string} Final action prompt
  */
-export const actionPrompt = (pageUrl, deviceType, cms = 'eds') =>`
-Perform your final exhaustive and detailed analysis for url ${pageUrl} on a ${deviceType} device.
+export const actionPrompt = (pageUrl, deviceType, cms = 'eds') => `
+Produce the final analysis and actionable suggestion list for ${pageUrl} on a ${deviceType} device.
+Your output is a ranked set of optimization suggestions — each one grounded in upstream agent findings, classified with a semanticType, and tied to concrete code changes.
 
 ${getTechnicalContext(cms)}
 
-## Phase 5: Graph-Enhanced Synthesis Instructions
+## Synthesis Rules
 
-If you receive "Root Cause Prioritization" data from the causal graph:
+### Prioritize Root Causes Over Symptoms
+If you receive "Root Cause Prioritization" data from the causal graph, apply these rules; otherwise infer root causes from the findings yourself.
 
-1. **Focus on Root Causes**: Prioritize suggestions that address root causes over symptoms
-   - Root causes are fundamental issues that cascade to multiple problems
-   - Fixing one root cause often resolves multiple symptoms
-   - Example: Unused code (root cause) → High TBT (symptom) → Poor INP (symptom)
+1. **Focus on root causes, not symptoms.** Root causes cascade to multiple problems; fixing one often resolves many.
+   Example: Unused code (root cause) → High TBT (symptom) → Poor INP (symptom).
+2. **Combine related findings into one suggestion** when they share a root cause. Do not emit a separate suggestion per symptom.
+   Example: Merge TBT + INP + LCP findings caused by the same unused code into one "Remove unused code" suggestion.
+3. **Order by total downstream impact.** Higher-impact root causes go first; describe cascading benefits in the suggestion.
+   Example: "Removing 1147KB unused code will improve TBT by 400ms, which cascades to INP improvement of ~200ms."
+4. **Respect graph depth.** Depth 1 = direct causes; depth 2+ = fundamental root causes — prefer depth 2+ for strategic suggestions.
 
-2. **Combine Related Findings**: When multiple findings share the same root cause, create ONE holistic suggestion
-   - Don't create separate suggestions for each symptom
-   - Address the root cause comprehensively
-   - Example: Instead of 3 separate suggestions for TBT, INP, and LCP, create one suggestion to remove unused code
+### Every Suggestion Must Have a semanticType
+The \`semanticType\` field drives downstream filtering, targeted analysis modes, and SpaceCat categorization.
 
-3. **Order by Total Impact**: Use the "Total downstream impact" to prioritize
-   - Higher impact root causes should appear first
-   - Show cascading benefits in the description
-   - Example: "Removing 1147KB unused code will improve TBT by 400ms, which cascades to INP improvement of ~200ms"
+- **Inherit from findings.** Use the semanticType of the primary finding the suggestion addresses.
+- **For merged suggestions.** Use the semanticType of the root cause finding.
+  Example: Merging unused-code + TBT + INP → \`unused-code\`.
+  Example: Merging lcp-image + CLS on the same image → \`lcp-image\`.
+- **When uncertain.** Prefer the most specific matching type; fall back to the finding with highest impact.
 
-4. **Respect Graph Depth**: Deeper root causes (depth 2-3) are more fundamental
-   - Depth 1: Direct causes (immediate problems)
-   - Depth 2+: Root causes (fundamental issues)
-   - Prioritize depth 2+ for strategic improvements
+Valid types (use the most specific that applies):
+- \`lcp-image\` — LCP-specific image issues (missing preload, fetchpriority, lazy-loading on the LCP element)
+- \`font-format\` — font format/loading issues (missing font-display, FOIT/FOUT)
+- \`font-preload\` — missing font preload or preconnect to font CDN
+- \`image-sizing\` — missing width/height/aspect-ratio causing CLS
+- \`unused-code\` — unused CSS/JS in bundles
+- \`js-execution\` — long tasks, heavy JavaScript execution
+- \`layout-shift\` — CLS issues (dynamic inserts, unsized elements)
+- \`blocking-resource\` — render-blocking CSS/JS
+- \`ttfb\` — server response time / backend
+- \`third-party\` — third-party scripts impacting performance
+- \`resource-preload\` — missing preload hints for critical resources
+- Add others as appropriate.
 
-## CRITICAL: Semantic Type Classification
+### Every Suggestion Must Include Concrete codeChanges
+- GOOD: \`{ "file": "/apps/myproject/components/content/hero/hero.html", "after": "..." }\`
+- BAD: \`{ "file": "Update your component template" }\`
 
-EVERY suggestion MUST include a semanticType field for downstream filtering and targeted analysis:
+Match code examples to the CMS architecture:
+- AEM AMS/CS → clientlib categories, HTL templates, dispatcher config
+- EDS → block structure, styles.css, lazy-styles.css
 
-1. **Inherit from findings**: When creating a suggestion from agent findings, use the semanticType from the primary finding
-   - If the suggestion addresses an LCP image issue, use "lcp-image"
-   - If the suggestion addresses font loading, use "font-format" or "font-preload"
-   - If the suggestion addresses missing image dimensions, use "image-sizing"
-
-2. **For merged suggestions**: When combining multiple findings into one suggestion, use the semantic type of the root cause finding
-   - Example: If merging unused-code + TBT + INP findings, use "unused-code" as semanticType
-   - Example: If merging lcp-image + CLS findings about the same image, use "lcp-image" as the primary type
-
-3. **Valid semantic types** (use the most specific type that matches):
-   - **lcp-image**: LCP-specific image issues (missing preload, fetchpriority, lazy loading on LCP element)
-   - **font-format**: Font format/loading issues (missing font-display, FOIT/FOUT)
-   - **font-preload**: Missing font preload hints or preconnect to font CDN
-   - **image-sizing**: Missing width/height/aspect-ratio attributes causing CLS
-   - **unused-code**: Code waste (unused CSS/JS in bundles)
-   - **js-execution**: Long tasks, heavy JavaScript execution
-   - **layout-shift**: CLS issues (dynamic content insertion, unsized elements)
-   - **blocking-resource**: Render-blocking CSS/JS resources
-   - **ttfb**: Server response time, backend performance
-   - **third-party**: Third-party scripts impacting performance
-   - **resource-preload**: Missing preload hints for critical resources
-   - And others as appropriate...
-
-4. **When uncertain**: Choose the most specific type that matches the primary issue being addressed
-   - Prefer specific types (lcp-image, font-preload) over generic types (resource-preload)
-   - If truly ambiguous, use the type of the finding with highest impact
-
-**Why this matters**: The semanticType field enables:
-- Targeted analysis modes (light mode for quick wins, full mode for comprehensive audit)
-- Downstream filtering by SpaceCat platform
-- Better categorization and prioritization of suggestions
-
-**Examples**:
-- Suggestion about hero image loading → semanticType: "lcp-image"
-- Suggestion about custom font optimization → semanticType: "font-format" or "font-preload"
-- Suggestion about images missing dimensions → semanticType: "image-sizing"
-- Suggestion about removing unused CSS → semanticType: "unused-code"
-
-## Code Change Requirements
-
-**Every suggestion MUST include codeChanges with AEM-specific file paths:**
-- ✅ GOOD: { "file": "/apps/myproject/components/content/hero/hero.html", "after": "..." }
-- ❌ BAD: { "file": "Update your component template" }
-
-**Match the CMS architecture:**
-- AEM AMS/CS: Show clientlib categories, HTL templates, dispatcher config
-- EDS: Show block structure, styles.css, lazy-styles.css
-
-**Before/After convention:**
-- Use "before" + "after" when modifying existing code (showing diff/replacement)
-- Use only "after" when adding new files or configurations
-- For multi-file changes, each file can independently use before/after or just after
+Before/after convention:
+- Modifying existing code → provide both \`before\` and \`after\`
+- Adding new files/config → \`after\` only
+- Multi-file changes → each file uses its own before/after (or just after)
 
 ${getDeliverableFormat()}
 `;

--- a/src/prompts/analysis.js
+++ b/src/prompts/analysis.js
@@ -129,11 +129,6 @@ export const rumSummaryStep = (rumSummary) => `
 Here is the Real User Monitoring (RUM) data from the last 7 days:
 
 ${rumSummary}
-
-**CRITICAL: Focus ONLY on "Current Page Metrics" section**
-- Report findings ONLY for the current page being analyzed
-- DO NOT report issues from "Other Pages on Site" unless marked as "CURRENT PAGE"
-- Site-wide metrics are provided for context/comparison only
 `;
 
 function getBasePrompt(role) {
@@ -216,6 +211,12 @@ Output:
 - Impact: Hero image without dimensions is consistent root cause
 - Confidence: 0.95 (cross-validated by two field data sources)`;
 
+  const additionalContext = `## Scope Constraint
+Focus ONLY on the "Current Page Metrics" section of the RUM payload.
+- Report findings ONLY for the current page being analyzed.
+- DO NOT report issues from "Other Pages on Site" unless that entry is explicitly marked as "CURRENT PAGE".
+- Site-wide metrics are provided for context/comparison only, not as findings.`;
+
   return createAgentPrompt({
     agentName: 'RUM Agent',
     role: 'analyzing Real User Monitoring (RUM) field data',
@@ -223,6 +224,7 @@ Output:
     focusKey: 'RUM',
     examples,
     cms,
+    additionalContext,
   });
 }
 

--- a/src/prompts/analysis.js
+++ b/src/prompts/analysis.js
@@ -185,6 +185,7 @@ Output:
     dataSource: 'crux',
     focusKey: 'CRUX',
     examples,
+    cms,
   });
 }
 
@@ -221,6 +222,7 @@ Output:
     dataSource: 'rum',
     focusKey: 'RUM',
     examples,
+    cms,
   });
 }
 
@@ -254,6 +256,7 @@ Output:
     dataSource: 'psi',
     focusKey: 'PSI',
     examples,
+    cms,
   });
 }
 
@@ -341,6 +344,7 @@ Output:
     focusKey: 'PERF_OBSERVER',
     examples,
     additionalContext,
+    cms,
   });
 }
 
@@ -456,6 +460,7 @@ Output:
     focusKey: 'HAR',
     examples,
     additionalContext,
+    cms,
   });
 }
 
@@ -560,6 +565,7 @@ Before recommending any preload/preconnect hints:
     focusKey: 'HTML',
     examples,
     additionalContext,
+    cms,
   });
 }
 
@@ -572,6 +578,7 @@ export function rulesAgentPrompt(cms = 'eds') {
     dataSource: 'rules',
     focusKey: 'RULES',
     examples,
+    cms,
   });
 }
 
@@ -622,6 +629,7 @@ Output:
     dataSource: 'coverage',
     focusKey: 'COVERAGE',
     examples,
+    cms,
   });
 }
 
@@ -638,6 +646,7 @@ ${PHASE_FOCUS.CODE_REVIEW}`;
     focusKey: 'CODE_REVIEW',
     examples,
     additionalContext,
+    cms,
   });
 }
 

--- a/src/prompts/contexts/aemcs.js
+++ b/src/prompts/contexts/aemcs.js
@@ -1,10 +1,15 @@
 /**
  * Technical context for AEM Cloud Service (CS)
+ *
+ * Exposed as named sections so agents can receive only what's relevant to
+ * their phase (see PHASE_CONTEXT in shared.js). AEMCSContext is the full
+ * string, preserved for single-context consumers (e.g. actionPrompt).
  */
-export const AEMCSContext = `
-You know the following about AEM CS.
- 
-### Characteristics
+
+const PREAMBLE = `You know the following about AEM CS.`;
+
+export const AEMCSSections = {
+  characteristics: `### Characteristics
 
 - Dispatcher and CDN layer managed by Adobe
 - Standard Adobe CDN is Fastly, with configuration capabilities
@@ -21,11 +26,9 @@ You know the following about AEM CS.
 - Dynamic server-side personalization possible via ContextHub
 - Page structure uses container/component hierarchy
 - ClientLibs can be categorized as "js", "css", "dependencies", etc.
-- Traffic is always on HTTPS
+- Traffic is always on HTTPS`,
 
-### Common Optimizations
-
-#### LCP
+  lcpOptimizations: `#### LCP Optimizations
 
 - Configure clientlibs properly with categories to control loading order
 - Set "async" and "defer" attributes to non-critical JavaScript
@@ -38,9 +41,9 @@ You know the following about AEM CS.
 - Optimize server-side rendering time for critical components
 - Implement proper image format selection (WebP) via adaptive serving
 - Implement preconnect for external domains used in the critical path
-- Use HTTP/2 Server Push for critical resources via Dispatcher configuration
+- Use HTTP/2 Server Push for critical resources via Dispatcher configuration`,
 
-#### CLS
+  clsOptimizations: `#### CLS Optimizations
 
 - Properly configure image dimensions in Core Components
 - Implement CSS best practices for layout stability
@@ -51,9 +54,9 @@ You know the following about AEM CS.
 - Properly configure font loading strategies
 - Utilize CSS containment where appropriate
 - Set explicit width/height for all media elements
-- Implement proper lazy loading strategies for below-the-fold content
+- Implement proper lazy loading strategies for below-the-fold content`,
 
-#### INP
+  inpOptimizations: `#### INP Optimizations
 
 - Optimize clientlib JavaScript for performance
 - Utilize efficient event delegation patterns
@@ -64,9 +67,9 @@ You know the following about AEM CS.
 - Optimize third-party script loading and execution
 - Implement proper task scheduling for JavaScript execution
 - Optimize event handlers to avoid long tasks
-- Break up large JavaScript operations into smaller chunks
+- Break up large JavaScript operations into smaller chunks`,
 
-### Anti-patterns
+  antiPatterns: `### Anti-patterns
 
 **CRITICAL - Absolutely prohibited (even if performance impact is severe):**
 - NEVER inline critical CSS for above-the-fold content in the <head> (requires build system not available in AEM). Instead, split clientlibs into critical (sync) and non-critical (async), load non-critical with JavaScript.
@@ -81,9 +84,9 @@ You know the following about AEM CS.
 - AVOID using deprecated AEM Foundation components that aren't optimized
 - AVOID depending on heavy jQuery operations for core functionality
 - AVOID excessive CSS specificity that leads to performance issues
-- AVOID implementing custom clientlib categories that bypass optimization
+- AVOID implementing custom clientlib categories that bypass optimization`,
 
-### Practical Implementation Constraints
+  implementationConstraints: `### Practical Implementation Constraints
 
 **Image Optimization Recommendations:**
 - AVOID: Suggesting page-specific <link rel="preload"> for hero images (not maintainable across site)
@@ -167,9 +170,9 @@ You know the following about AEM CS.
 - Always provide AEM-specific implementation paths (HTL templates, clientlib categories, Dispatcher config)
 - Show actual file locations: /apps/myproject/components/content/hero/hero.html
 - Include Dispatcher configuration snippets when suggesting caching changes
-- Reference Core Components version-specific APIs when applicable
+- Reference Core Components version-specific APIs when applicable`,
 
-### TTFB Optimization and Caching
+  ttfbCaching: `### TTFB Optimization and Caching
 
 **Dispatcher Cache Detection:**
 - X-Dispatcher-Cache header indicates cache status: "HIT" (cached) or "MISS" (origin fetch)
@@ -241,6 +244,25 @@ Set Cache-Control headers:
 - Static assets (JS/CSS/images): max-age=31536000 (1 year) with versioned URLs
 - HTML pages: max-age=300-3600 depending on content freshness needs
 - API responses: Cache-Control: no-store for personalized content
-- Use stale-while-revalidate for improved perceived performance
+- Use stale-while-revalidate for improved perceived performance`,
+};
+
+export const AEMCSContext = `
+${PREAMBLE}
+
+${AEMCSSections.characteristics}
+
+### Common Optimizations
+
+${AEMCSSections.lcpOptimizations}
+
+${AEMCSSections.clsOptimizations}
+
+${AEMCSSections.inpOptimizations}
+
+${AEMCSSections.antiPatterns}
+
+${AEMCSSections.implementationConstraints}
+
+${AEMCSSections.ttfbCaching}
 `;
- 

--- a/src/prompts/contexts/ams.js
+++ b/src/prompts/contexts/ams.js
@@ -1,10 +1,15 @@
 /**
  * Technical context for AEM Managed Services (AMS)
+ *
+ * Exposed as named sections so agents can receive only what's relevant to
+ * their phase (see PHASE_CONTEXT in shared.js). AMSContext is the full
+ * string, preserved for single-context consumers (e.g. actionPrompt).
  */
-export const AMSContext = `
-You know the following about AEM AMS.
- 
-### Characteristics
+
+const PREAMBLE = `You know the following about AEM AMS.`;
+
+export const AMSSections = {
+  characteristics: `### Characteristics
 
 - Dispatcher and publish instances managed by Adobe operations team
 - Custom CDN configuration possible (Akamai/Fastly/others)
@@ -20,11 +25,9 @@ You know the following about AEM AMS.
 - Deployment through Adobe's Release Management process
 - Custom replication agents often implemented
 - Dispatcher flush agents handle cache invalidation
-- Traffic may use HTTP/HTTPS with potential mixed content
+- Traffic may use HTTP/HTTPS with potential mixed content`,
 
-### Common Optimizations
-
-#### LCP
+  lcpOptimizations: `#### LCP Optimizations
 
 - Optimize Dispatcher TTL settings for static resources
 - Configure CDN properly for edge caching of assets
@@ -37,9 +40,9 @@ You know the following about AEM AMS.
 - Optimize component rendering sequence for critical content
 - Implement proper HTML caching strategies at the Dispatcher level
 - Configure proper flush agents to maintain cache freshness
-- Apply proper image sizing and format selection for hero images
+- Apply proper image sizing and format selection for hero images`,
 
-#### CLS
+  clsOptimizations: `#### CLS Optimizations
 
 - Ensure all images have proper dimensions specified
 - Implement proper font-loading strategies
@@ -50,9 +53,9 @@ You know the following about AEM AMS.
 - Implement progressive enhancement for dynamic content
 - Ensure proper responsive behaviors for all viewport sizes
 - Properly handle lazy-loaded content to maintain layout stability
-- Implement content placeholders during loading phases
+- Implement content placeholders during loading phases`,
 
-#### INP
+  inpOptimizations: `#### INP Optimizations
 
 - Optimize JavaScript execution in critical path
 - Implement efficient event handling patterns
@@ -63,9 +66,9 @@ You know the following about AEM AMS.
 - Apply proper debouncing and throttling for event handlers
 - Optimize DOM interaction patterns in JavaScript
 - Implement efficient data structures for complex operations
-- Apply proper task scheduling to prevent long tasks
+- Apply proper task scheduling to prevent long tasks`,
 
-### Anti-patterns
+  antiPatterns: `### Anti-patterns
 
 **CRITICAL - Absolutely prohibited (even if performance impact is severe):**
 - NEVER inline critical CSS for above-the-fold content in the <head> (requires build system not available in AEM). Instead, split clientlibs into critical (sync) and non-critical (async), load non-critical with JavaScript.
@@ -80,9 +83,9 @@ You know the following about AEM AMS.
 - AVOID relying on inefficient jQuery selectors for critical operations
 - AVOID implementing render-blocking resource loading
 - AVOID neglecting proper cache invalidation strategies
-- AVOID implementing excessive server-side processing for initial render
+- AVOID implementing excessive server-side processing for initial render`,
 
-### Practical Implementation Constraints
+  implementationConstraints: `### Practical Implementation Constraints
 
 **Image Optimization Recommendations:**
 - AVOID: Suggesting page-specific <link rel="preload"> for hero images (not maintainable across site)
@@ -167,5 +170,23 @@ You know the following about AEM AMS.
 - Always provide AEM-specific implementation paths (HTL templates, clientlib categories, Dispatcher config)
 - Show actual file locations: /apps/myproject/components/content/hero/hero.html
 - Include Dispatcher configuration snippets when suggesting caching changes
-- Reference Core Components version-specific APIs when applicable
-`; 
+- Reference Core Components version-specific APIs when applicable`,
+};
+
+export const AMSContext = `
+${PREAMBLE}
+
+${AMSSections.characteristics}
+
+### Common Optimizations
+
+${AMSSections.lcpOptimizations}
+
+${AMSSections.clsOptimizations}
+
+${AMSSections.inpOptimizations}
+
+${AMSSections.antiPatterns}
+
+${AMSSections.implementationConstraints}
+`;

--- a/src/prompts/contexts/eds.js
+++ b/src/prompts/contexts/eds.js
@@ -1,11 +1,16 @@
 /**
  * Technical context for AEM Experience Delivery Service (EDS)
+ *
+ * Exposed as named sections so agents can receive only what's relevant to
+ * their phase (see PHASE_CONTEXT in shared.js). EDSContext is the full
+ * string, preserved for single-context consumers (e.g. actionPrompt).
  */
-export const EDSContext = `
-You know the following about AEM EDS.
- 
-### Characteristics
- 
+
+const PREAMBLE = `You know the following about AEM EDS.`;
+
+export const EDSSections = {
+  characteristics: `### Characteristics
+
 - the page typically has references either "aem.js" or "lib-franklin.js" in the frontend code (but is not mandatory), a reference to "scripts.js"
 - the markup has "data-block-status" data attributes
 - the main CDN used is Fastly. Fastly VCL and configs cannot be modified
@@ -25,12 +30,10 @@ You know the following about AEM EDS.
 - custom fonts are loaded asynchronously in the lazy phase to free up the critical path
 - HTTP headers can be set for individual pages (i.e. "/home"), or all pages following a generic pattern (i.e. "/products/**")
 - The HTML <head> is mostly global for the whole site, and only individual metadata can be changed without a global impact
-- Traffic is always on HTTPS
- 
-### Common Optimizations
- 
-#### LCP
- 
+- Traffic is always on HTTPS`,
+
+  lcpOptimizations: `#### LCP Optimizations
+
 - cleaning up the critical path for the LCP by delaying unused dependencies, martech and third-party libraries
 - leveraging inline imports to do tree shaking of the JavaScript files at runtime
 - making sure images above the fold, especially in the hero section or block and for the LCP element, are loaded eagerly and with a high fetch-priority. The initial markup itself cannot be modified, so this is typically done via Javascript
@@ -40,35 +43,35 @@ You know the following about AEM EDS.
 - header and footer should be loaded in the "loadLazy" phase
 - self-hosting third-party resources (like martech, custom fonts, etc.). This helps reduce the number of external hosts that need to be resolved and the number of TLS connections that need to be established
 - preloading critical JS and CSS files needed to render the LCP directly in the HTML head or via HTTP Link headers (better) to benefit from Early Hints
-- defer third-party embeds (like maps, videos, social widgets, etc.) with a "facade" (i.e. placeholder) and only load them using an Intersection Observer or an actual user interaction
- 
-#### CLS
- 
+- defer third-party embeds (like maps, videos, social widgets, etc.) with a "facade" (i.e. placeholder) and only load them using an Intersection Observer or an actual user interaction`,
+
+  clsOptimizations: `#### CLS Optimizations
+
 - ensure all images have proper height and width, or an aspect ratio defined
 - making sure that the CSS uses "scrollbar-gutter: stable;" to avoid CLS when the page is longer than the initial viewport
 - loading any page template files (CSS and JS) in the eager phase before the LCP
 - setting a minimum height on the blocks that are loaded asynchronously to avoid CLS after the block is shown
-- when custom fonts are used, they should have the "font-display: swap;" CSS property, and there should also be a fallback font for it in styles.css using a safe web font that has the "size-adjust" CSS property to reduce CLS
- 
-#### INP
- 
+- when custom fonts are used, they should have the "font-display: swap;" CSS property, and there should also be a fallback font for it in styles.css using a safe web font that has the "size-adjust" CSS property to reduce CLS`,
+
+  inpOptimizations: `#### INP Optimizations
+
 - deferring all third-party logic to the delayed phase (except for the experimentation/personalization libraries)
 - removing unused tags from the tag manager containers
 - breaking up long tasks in event handlers at the project level by leveraging "window.requestAnimationFrame", "window.requestIdleCallback", "window.setTimeout" or "scheduler.yield" APIs
 - patching datalayer push operations to forcibly yield to the main thread, so first party event handlers are prioritized and third-party metrics tracking is executed afterwards
-- patching global event listeners like "load", "DOMContentLoaded", "click", etc. to forcibly yield to the main thread, so first party event handlers are prioritized and third-party metrics tracking is executed afterwards
- 
-### Anti-patterns
- 
+- patching global event listeners like "load", "DOMContentLoaded", "click", etc. to forcibly yield to the main thread, so first party event handlers are prioritized and third-party metrics tracking is executed afterwards`,
+
+  antiPatterns: `### Anti-patterns
+
 - NEVER inline critical CSS for above-the-fold content in the <head> (requires build system). Use separate styles.css and lazy-styles.css files instead. Inline CSS is a common web performance best practice but is NOT compatible with EDS architecture.
 - Do not minify CSS and JS files. The files are already small, HTTP compression is already properly configured, and it would again require a build system
 - Do not preload the LCP image via meta tags or HTTP headers. Setting loading to eager and fetchpriority to high using Javascript is the recommended approach. The initial markup itself cannot be modified
 - Do not add defer or async to third-party scripts in the head. "aem.js"/"lib-franklin.js" are modules and anyways loaded like "defer". Instead load those dependencies via the "loadDelayed" method
 - Do not preload JS and CSS for individual blocks. This is considered overkill and would require page-specific rules that won't scale
 - Do not preload custom fonts. This would clutter the LCP critical path. Instead, defer the fonts to the lazy phase with appropriate font fallbacks defined
-- Do not preload/preconnect any third-party resource that is not in the critical path for the LCP. Instead, let them load async in "loadLazy" or "loadDelayed"
+- Do not preload/preconnect any third-party resource that is not in the critical path for the LCP. Instead, let them load async in "loadLazy" or "loadDelayed"`,
 
-### Practical Implementation Constraints
+  implementationConstraints: `### Practical Implementation Constraints
 
 **Image Optimization Recommendations:**
 - AVOID: Suggesting page-specific <link rel="preload"> for hero images (not maintainable across site)
@@ -99,5 +102,23 @@ You know the following about AEM EDS.
 - Always provide AEM-specific implementation paths (HTL templates, clientlib categories, Dispatcher config)
 - Show actual file locations: /apps/myproject/components/content/hero/hero.html
 - Include Dispatcher configuration snippets when suggesting caching changes
-- Reference Core Components version-specific APIs when applicable
-`; 
+- Reference Core Components version-specific APIs when applicable`,
+};
+
+export const EDSContext = `
+${PREAMBLE}
+
+${EDSSections.characteristics}
+
+### Common Optimizations
+
+${EDSSections.lcpOptimizations}
+
+${EDSSections.clsOptimizations}
+
+${EDSSections.inpOptimizations}
+
+${EDSSections.antiPatterns}
+
+${EDSSections.implementationConstraints}
+`;

--- a/src/prompts/initialize.js
+++ b/src/prompts/initialize.js
@@ -1,4 +1,9 @@
-import { getTechnicalContext, getCriticalFilteringCriteria, getCommonAnalysisPriorities } from './shared.js';
+import {
+  getTechnicalContext,
+  getCriticalFilteringCriteria,
+  getCommonAnalysisPriorities,
+  BASELINE_CONTEXT_SECTIONS,
+} from './shared.js';
 
 /**
  * Initial context optimized for multi-agent flow (global system prompt)
@@ -35,7 +40,7 @@ ${errorIssues.length > 0 ? '- Some critical data sources failed - analysis may b
   return `You are a web performance expert analyzing Core Web Vitals for an AEM website.
 
 ## Technical Context
-${getTechnicalContext(cms)}
+${getTechnicalContext(cms, BASELINE_CONTEXT_SECTIONS)}
 
 ${getCommonAnalysisPriorities()}
 

--- a/src/prompts/shared.js
+++ b/src/prompts/shared.js
@@ -1,6 +1,6 @@
-import { EDSContext } from './contexts/eds.js';
-import { AEMCSContext } from './contexts/aemcs.js';
-import { AMSContext } from './contexts/ams.js';
+import { EDSContext, EDSSections } from './contexts/eds.js';
+import { AEMCSContext, AEMCSSections } from './contexts/aemcs.js';
+import { AMSContext, AMSSections } from './contexts/ams.js';
 
 /**
  * Chain-of-Thought reasoning instructions shared by all agents
@@ -55,12 +55,73 @@ Be concrete with file names, sizes (KB), timings (ms), and metric values. Refere
 `;
 }
 
+const CMS_SECTIONS = {
+  eds: EDSSections,
+  cs: AEMCSSections,
+  ams: AMSSections,
+};
+
 /**
- * Returns CMS-specific technical context text
- * @param {String} cms
+ * Baseline sections every agent sees — enough to know the platform,
+ * nothing about how to optimize it.
+ */
+export const BASELINE_CONTEXT_SECTIONS = ['characteristics'];
+
+/**
+ * Phase-scoped section keys per agent data source. Agents analyzing field
+ * data (crux, rum) only need to understand the platform; the HAR, HTML and
+ * code-review agents need the optimization patterns and anti-patterns
+ * relevant to their phase. `code` gets the full context.
+ *
+ * Keys here match the `dataSource` parameter used by createAgentPrompt.
+ */
+const ALL_OPTIMIZATION_SECTIONS = [
+  'lcpOptimizations',
+  'clsOptimizations',
+  'inpOptimizations',
+  'antiPatterns',
+  'implementationConstraints',
+  'ttfbCaching',
+];
+
+export const PHASE_CONTEXT = {
+  crux: ['characteristics'],
+  rum: ['characteristics'],
+  psi: ['characteristics', 'lcpOptimizations', 'clsOptimizations', 'inpOptimizations', 'antiPatterns'],
+  perf_observer: ['characteristics', 'lcpOptimizations', 'clsOptimizations', 'inpOptimizations'],
+  har: ['characteristics', 'lcpOptimizations', 'antiPatterns', 'implementationConstraints', 'ttfbCaching'],
+  html: ['characteristics', 'lcpOptimizations', 'clsOptimizations', 'antiPatterns', 'implementationConstraints'],
+  rules: ['characteristics', 'lcpOptimizations', 'clsOptimizations', 'inpOptimizations', 'antiPatterns'],
+  coverage: ['characteristics', 'antiPatterns', 'implementationConstraints'],
+  code: ['characteristics', ...ALL_OPTIMIZATION_SECTIONS],
+};
+
+/**
+ * Returns CMS-specific technical context text.
+ *
+ * @param {String} cms - CMS identifier (eds, cs, ams, aem-headless, or other)
+ * @param {String[]} [sectionKeys] - Optional list of section keys to include
+ *   (e.g. ['characteristics', 'lcpOptimizations']). When omitted or null,
+ *   the full context is returned — preserves existing single-shot/synthesis
+ *   behaviour. Section keys that don't exist on a given CMS (e.g. ttfbCaching
+ *   is only on AEM CS) are silently skipped.
  * @return {String}
  */
-export function getTechnicalContext(cms) {
+export function getTechnicalContext(cms, sectionKeys = null) {
+  if (sectionKeys) {
+    const sections = CMS_SECTIONS[cms];
+    if (sections) {
+      return sectionKeys
+        .map((key) => sections[key])
+        .filter(Boolean)
+        .join('\n\n');
+    }
+    if (sectionKeys.includes('characteristics')) {
+      return (cms === 'aem-headless' && 'The website uses AEM Headless as a backend system.')
+        || 'The CMS serving the site does not seem to be any version of AEM.';
+    }
+    return '';
+  }
   return (cms === 'eds' && EDSContext)
     || (cms === 'cs' && AEMCSContext)
     || (cms === 'ams' && AMSContext)

--- a/src/prompts/templates/base-agent-template.js
+++ b/src/prompts/templates/base-agent-template.js
@@ -5,10 +5,36 @@
 
 import {
   PHASE_FOCUS,
+  PHASE_CONTEXT,
+  BASELINE_CONTEXT_SECTIONS,
   getDataPriorityGuidance,
   getChainOfThoughtGuidance,
   getStructuredOutputFormat,
+  getTechnicalContext,
 } from '../shared.js';
+
+/**
+ * Returns the CMS technical context an agent needs, minus whatever the
+ * global baseline already carried. PHASE_CONTEXT[dataSource] declares the
+ * sections relevant to this phase; we remove BASELINE_CONTEXT_SECTIONS so
+ * the same characteristics block isn't repeated in the combined system
+ * message (globalSystemPrompt + per-agent systemPrompt).
+ *
+ * @param {string} cms
+ * @param {string} dataSource
+ * @returns {string} Phase-scoped context, or '' when the phase only needs
+ *   the baseline or the dataSource has no entry.
+ */
+function getPhaseScopedContext(cms, dataSource) {
+  if (!cms || !dataSource) return '';
+  const phaseSections = PHASE_CONTEXT[dataSource];
+  if (!phaseSections) return '';
+  const additionalSections = phaseSections.filter(
+    (s) => !BASELINE_CONTEXT_SECTIONS.includes(s),
+  );
+  if (additionalSections.length === 0) return '';
+  return getTechnicalContext(cms, additionalSections);
+}
 
 /**
  * Creates a standardized agent prompt with shared components
@@ -19,6 +45,9 @@ import {
  * @param {string} config.dataSource - Data source key for priority guidance (e.g., 'crux', 'psi', 'har')
  * @param {string} config.focusKey - Key in PHASE_FOCUS object (e.g., 'CRUX', 'PSI', 'HAR')
  * @param {string} config.examples - Few-shot examples specific to this agent
+ * @param {string} [config.cms] - CMS identifier used to pull phase-scoped
+ *   technical context. When omitted, no CMS context is added here (it still
+ *   arrives via the global system prompt baseline).
  * @param {string} [config.additionalContext] - Optional additional context sections
  * @returns {string} Complete agent prompt
  */
@@ -29,8 +58,14 @@ export function createAgentPrompt(config) {
     dataSource,
     focusKey,
     examples,
+    cms,
     additionalContext = '',
   } = config;
+
+  const phaseContext = getPhaseScopedContext(cms, dataSource);
+  const phaseContextBlock = phaseContext
+    ? `## Platform-Specific Optimizations\n${phaseContext}\n\n`
+    : '';
 
   return `You are ${role} for Core Web Vitals optimization.
 
@@ -38,7 +73,7 @@ ${getDataPriorityGuidance(dataSource)}
 
 ${getChainOfThoughtGuidance()}
 
-${examples ? `## Few-Shot Examples\n\n${examples}\n\n` : ''}${additionalContext ? `${additionalContext}\n\n` : ''}## Your Analysis Focus
+${phaseContextBlock}${examples ? `## Few-Shot Examples\n\n${examples}\n\n` : ''}${additionalContext ? `${additionalContext}\n\n` : ''}## Your Analysis Focus
 ${PHASE_FOCUS[focusKey]}
 
 ${getStructuredOutputFormat(agentName)}


### PR DESCRIPTION
## Summary

Trim the per-agent prompt envelope by layering CMS technical context into phase-scoped sections instead of blasting every sub-agent with the full context. Also tighten two other prompts where structure was hurting predictability.

## 1. Phase-scoped CMS context (primary change)

**Problem:** On `v2`, the global system prompt carries the entire CMS context (EDS/AMS/AEMCS) — characteristics, every LCP/CLS/INP optimization block, anti-patterns, implementation constraints. Field-data-only agents (CrUX, RUM) are told to analyze p75 metrics but also receive 100+ lines of guidance about CSS clientlib splitting, `media="print"` hacks, preconnect categories, etc. Noise, wasted tokens, less steerable per-phase behavior.

**Fix:** Split each CMS context file into named sections. Add a declarative `PHASE_CONTEXT` map from data source → section keys. The global prompt only carries the baseline (`characteristics`). Each agent prompt, built via `createAgentPrompt`, layers in just the optimization/anti-pattern sections its phase actually reasons about.

### Changes
- `contexts/{eds,aemcs,ams}.js` — export `*Sections` objects alongside existing full-string `*Context` (backward-compat for `actionPrompt`).
- `shared.js` — add `BASELINE_CONTEXT_SECTIONS`, `PHASE_CONTEXT`, and teach `getTechnicalContext(cms, sectionKeys)` to compose only the requested sections. `sectionKeys = null` keeps full output.
- `initialize.js` — `initializeSystemAgents` now calls `getTechnicalContext(cms, BASELINE_CONTEXT_SECTIONS)`. Optimization guidance moves to per-agent prompts.
- `templates/base-agent-template.js` — `createAgentPrompt` accepts `cms`, filters phase sections to exclude baseline (no duplication with global), and injects a `## Platform-Specific Optimizations` block.
- `analysis.js` — every `createAgentPrompt` call passes `cms` through.

### Result

Rendered prompt sizes (`eds`):

| Agent | Platform block | LCP guidance |
|---|---|---|
| CrUX | no | no |
| RUM | no | no |
| PSI | yes | yes |
| Perf Observer | yes | yes |
| HAR | yes | yes |
| HTML | yes | yes |
| Rules | yes | yes |
| Coverage | yes | no (anti-patterns + constraints only) |
| Code Review | yes | yes |
| `actionPrompt` | unchanged — full context |

`Characteristics` appears exactly once (in global) regardless of agent.

## 2. Tighten `actionPrompt` (spec-shape follow-up)

The final synthesis prompt had a one-line task buried at the top, then ~85 lines of "Phase 5 synthesis rules + semantic type classification + code change requirements + output format". The task was visually outweighed by the constraints.

Restructured to: clear task statement → technical context → `## Synthesis Rules` section with three grouped sub-constraints (root-cause prioritization, `semanticType` assignment, concrete `codeChanges`) → output format via `getDeliverableFormat()`. Content is equivalent, just reorganized so what the model should produce is prominent and constraints are grouped. The misleading "Phase 5" label is dropped (it wasn't actually phase-scoped).

## 3. Fix instruction-in-data payload in `rumSummaryStep`

`rumSummaryStep` was mixing a directive (`**CRITICAL: Focus ONLY on Current Page Metrics**`) into the data payload (the `HumanMessage`). Moved it to the RUM agent's system prompt via `additionalContext` so instructions live with instructions and data lives with data.

## Test plan

- [x] `node --check` on all modified prompt files
- [x] Render each of the 9 agent prompts with `cms = eds | cs | ams` — no crashes, expected section shape
- [x] `actionPrompt('...', 'mobile', 'eds')` renders — task intro present, `## Synthesis Rules` present, `semanticType` present, `Phase 5` label gone, deliverable format intact
- [x] `initializeSystemAgents('eds')` contains `Characteristics` but NOT `LCP Optimizations`
- [x] `rumAgentPrompt('eds')` now contains `## Scope Constraint` with `Current Page Metrics` rule; `rumSummaryStep` is a thin data payload with no `CRITICAL` directive
- [ ] End-to-end analysis against a real URL to confirm no behavior regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)